### PR TITLE
Implement PEP-518 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ webpage, so you need an Internet connection and all OpenFst dependencies.
 Essentially, you will need:
 
 - A C++ compiler supporting C++11 (tested with GCC 4.9).
+- [Automake](https://www.gnu.org/software/automake/)
 - [PatchELF](https://nixos.org/patchelf.html).
 - [Zlib development](https://zlib.net/).
 - [Python Requests](http://docs.python-requests.org).
@@ -36,7 +37,7 @@ pip install openfst-python
 Alternatively, if you are installing from sources, you can simply do:
 
 ```bash
-python setup.py install
+pip install .
 ```
 
 Notice that this downloads the appropriate version of OpenFst directly from

--- a/create_wheels.sh
+++ b/create_wheels.sh
@@ -36,10 +36,9 @@ for py in cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m; do
   export PYTHON=/opt/python/$py/bin/python;
   echo "=== Installing dependencies for $py ===";
   $PYTHON -m pip install -U pip;
-  $PYTHON -m pip install -U requests wheel setuptools;
+  $PYTHON -m pip install -U wheel setuptools build;
   echo "=== Building for $py ==="
-  $PYTHON setup.py clean;
-  $PYTHON setup.py bdist_wheel;
+  $PYTHON -m build --wheel;
   echo "=== Installing for $py ===";
   cd /tmp;
   $PYTHON -m pip uninstall -y openfst_python;

--- a/create_wheels.sh
+++ b/create_wheels.sh
@@ -38,6 +38,7 @@ for py in cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m; do
   $PYTHON -m pip install -U pip;
   $PYTHON -m pip install -U wheel setuptools build;
   echo "=== Building for $py ==="
+  rm -rf build dist *.egg-info
   $PYTHON -m build --wheel;
   echo "=== Installing for $py ===";
   cd /tmp;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "Cython", "requests"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
PEP-518 becomes very essential nowadays.
It prevents multi-step pip install when building from source:

```sh
# before
pip install setuptools requests cython
pip install openfst-python

# after
pip install openfst-python
```

Besides, tools like [Poetry](https://python-poetry.org/) won't even work if the build requirements are not defined using PEP-518.

Reference: [Build System Support - setuptools](https://setuptools.pypa.io/en/latest/build_meta.html).

What I have tested (using CPython 3.8.10):

1. `pip install .` without installing any Python packages beforehand.
2. `pip install git+https://github.com/ianlini/openfst-python.git@pep-518`, which is actually very similar to 1.
3. `python -m build --sdist` and then `pip install dist/openfst_python-1.7.9.tar.gz`.
4. `python -m build --wheel`  and then `pip install dist/openfst_python-1.7.9-cp38-cp38-linux_x86_64.whl`.

All of them work as expected.

However, I didn't test `create_wheels.sh` because it looks quite complicated. I also recommend adding `python -m build --sdist` into `create_wheels.sh` so that you won't forget to publish the source distribution. For example, 1.7.3 on PyPI doesn't include the source distribution.